### PR TITLE
Add Ruff & mypy linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Ruff lint
+        run: ruff check .
+      - name: Mypy
+        run: mypy sec_edgar_mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,17 @@ packages = ["sec_edgar_mcp"]
 [project.urls]
 "Homepage" = "https://github.com/stefanoamorelli/sec-edgar-mcp"
 "Bug Tracker" = "https://github.com/stefanoamorelli/sec-edgar-mcp/issues"
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.1.14",
+    "mypy>=1.8",
+]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true

--- a/sec_edgar_mcp/server.py
+++ b/sec_edgar_mcp/server.py
@@ -60,9 +60,7 @@ def get_company_concepts_tool(
 
 
 @mcp.tool("get_company_facts")
-def get_company_facts_tool(
-    lookups: Union[str, List[str]], user_agent: str = sec_edgar_user_agent
-) -> Dict[str, dict]:
+def get_company_facts_tool(lookups: Union[str, List[str]], user_agent: str = sec_edgar_user_agent) -> Dict[str, dict]:
     """
     Retrieve all standardized financial facts for specified companies using the SEC EDGAR REST API.
 


### PR DESCRIPTION
## Summary
- configure optional dev deps for ruff & mypy
- add ruff and mypy settings
- format `server.py`
- add GitHub Actions workflow running ruff format/lint and mypy on PRs

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy sec_edgar_mcp`


------
https://chatgpt.com/codex/tasks/task_e_683f5c75ba1c832fb2308ca0f8e6b068