### PR TITLE
Analyze 8-K tool bug fix

### DIFF
--- a/sec_edgar_mcp/tools/filings.py
+++ b/sec_edgar_mcp/tools/filings.py
@@ -133,7 +133,9 @@ class FilingsTools:
             eightk = filing.obj()
 
             analysis: Dict[str, Any] = {
-                "date_of_report": datetime.strptime(eightk.date_of_report, "%B %d, %Y").isoformat() if hasattr(eightk, "date_of_report") else None,
+                "date_of_report": datetime.strptime(eightk.date_of_report, "%B %d, %Y").isoformat()
+                if hasattr(eightk, "date_of_report")
+                else None,
                 "items": getattr(eightk, "items", []),
                 "events": {},
             }

--- a/sec_edgar_mcp/tools/filings.py
+++ b/sec_edgar_mcp/tools/filings.py
@@ -162,7 +162,7 @@ class FilingsTools:
             if hasattr(eightk, "has_press_release"):
                 analysis["has_press_release"] = eightk.has_press_release
                 if eightk.has_press_release and hasattr(eightk, "press_releases"):
-                    analysis["press_releases"] = [pr.title for pr in eightk.press_releases[:3]]
+                    analysis["press_releases"] = [pr for pr in list(eightk.press_releases)[:3]]
 
             return {"success": True, "analysis": analysis}
         except Exception as e:

--- a/sec_edgar_mcp/tools/filings.py
+++ b/sec_edgar_mcp/tools/filings.py
@@ -133,7 +133,7 @@ class FilingsTools:
             eightk = filing.obj()
 
             analysis: Dict[str, Any] = {
-                "date_of_report": eightk.date_of_report.isoformat() if hasattr(eightk, "date_of_report") else None,
+                "date_of_report": datetime.strptime(eightk.date_of_report, "%B %d, %Y").isoformat() if hasattr(eightk, "date_of_report") else None,
                 "items": getattr(eightk, "items", []),
                 "events": {},
             }


### PR DESCRIPTION
Reproducing the bug with the following query:
```
Analyze the latest 8-K for Apple for me
```

The `analyze_8k` tool call in its current form fails with the error
```
{
  "success": false,
  "error": "Failed to analyze 8-K: 'str' object has no attribute 'isoformat'"
}
```
This is because the [edgartools package](https://github.com/dgunning/edgartools/blob/29012858f9e78358ae627e18fde6956f133083bd/edgar/company_reports.py#L777) returns the date_of_report property as a string. So it needs to parsed back into a datetime object with `datetime.strptime` before converting to the desired isoformat.

The tool will also subsequently fail with this error at a later step
```
{
  "success": false,
  "error": "Failed to analyze 8-K: 'PressRelease' object is not iterable"
}
```
Again this depends on the implementation of the `PressReleases` class in edgartools but a quick fix was to wrap it with `list()`. Also noticed that `PressRelease` does not have a title property or attribute so I removed that.

With these proposed changes, the `analyze_8k` tool call works as expected.

