### PR TITLE
feat: add PyPI publishing workflow and fix Conda build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.11', '3.12', '3.13']
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      
+      - name: Lint with ruff
+        run: |
+          ruff check sec_edgar_mcp
+          ruff format --check sec_edgar_mcp
+      
+      - name: Type check with mypy
+        run: mypy sec_edgar_mcp
+      
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+      
+      - name: Test import
+        run: python -c "import sec_edgar_mcp; print(sec_edgar_mcp.__version__)"
+      
+      - name: Verify server can start
+        env:
+          SEC_EDGAR_USER_AGENT: "Test User (test@example.com)"
+        run: |
+          timeout 5 python -m sec_edgar_mcp.server || exit_code=$?
+          if [ "$exit_code" = "124" ]; then
+            echo "Server started successfully (timeout expected)"
+            exit 0
+          else
+            echo "Server failed to start"
+            exit 1
+          fi
+        shell: bash
+        if: matrix.os != 'windows-latest'
+      
+      - name: Verify server can start (Windows)
+        env:
+          SEC_EDGAR_USER_AGENT: "Test User (test@example.com)"
+        run: |
+          $process = Start-Process python -ArgumentList "-m", "sec_edgar_mcp.server" -PassThru
+          Start-Sleep -Seconds 5
+          if ($process.HasExited) {
+            Write-Error "Server failed to start"
+            exit 1
+          } else {
+            Stop-Process -Id $process.Id -Force
+            Write-Host "Server started successfully"
+          }
+        shell: pwsh
+        if: matrix.os == 'windows-latest'

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,105 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to TestPyPI instead of PyPI'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Check package with twine
+        run: twine check dist/*
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sec-edgar-mcp
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test_pypi)
+    
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/sec-edgar-mcp
+    permissions:
+      id-token: write
+    if: github.event_name == 'workflow_dispatch' && inputs.test_pypi
+    
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  github-release:
+    name: Upload to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Upload to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload '${{ github.ref_name }}' dist/** --repo ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ ENV/
 .coverage
 htmlcov/
 .pytest_cache/
+test-dist/

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sec-edgar-mcp" %}
-{% set version = "0.2.0" %}
+{% set version = environ.get('GIT_DESCRIBE_TAG', '1.0.0').lstrip('v') %}
 
 package:
   name: {{ name|lower }}
@@ -15,13 +15,14 @@ build:
 
 requirements:
   host:
-    - python >=3.13
+    - python >=3.11
     - pip
     - setuptools >=61.0
-    - beautifulsoup4 >=4.12.0
   run:
-    - python >=3.13
-    - pip
+    - python >=3.11
+    - mcp-cli >=1.7.1
+    - edgartools >=4.4.0
+    - requests >=2.31.0
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "SEC EDGAR MCP server for company filings and financial data"
 authors = [{ name = "Stefano Amorelli", email = "stefano@amorelli.tech" }]
 readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "LICENSE" }
+license = { text = "AGPL-3.0" }
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: GNU Affero General Public License v3",
@@ -21,8 +21,9 @@ dependencies = [
   "requests>=2.31.0",
 ]
 
-[tool.setuptools]
-packages = ["sec_edgar_mcp"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sec_edgar_mcp*"]
 
 [project.urls]
 "Homepage" = "https://github.com/stefanoamorelli/sec-edgar-mcp"


### PR DESCRIPTION
## Summary
- Add PyPI/TestPyPI publishing workflow with trusted publishing (no tokens needed)
- Add comprehensive CI workflow for cross-platform testing (Python 3.11-3.13, Ubuntu/Windows/macOS)
- Fix Conda build issues:
  - Dynamic version detection from Git tags
  - Correct Python requirement (3.11 instead of 3.13)
  - Proper runtime dependencies

## Changes
- New workflow: `.github/workflows/publish_pypi.yml` - publishes to PyPI on release
- New workflow: `.github/workflows/ci.yml` - runs tests across platforms
- Fixed: `conda/meta.yaml` - now works with current project requirements
- Updated: `pyproject.toml` - improved package configuration

## Testing
- ✅ Package builds successfully
- ✅ Twine validation passes
- ✅ Linting and type checking pass
- ✅ Workflow YAML files validated

## Next Steps
After merge, you'll need to:
1. Run `./setup_environments.sh` locally to create GitHub environments
2. Configure trusted publishing on PyPI/TestPyPI
3. Your ANACONDA_TOKEN is already set up and ready to use