### PR TITLE
Add support for running from uvx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ include = ["sec_edgar_mcp*"]
 "Homepage" = "https://github.com/stefanoamorelli/sec-edgar-mcp"
 "Bug Tracker" = "https://github.com/stefanoamorelli/sec-edgar-mcp/issues"
 
+[project.scripts]
+sec-edgar-mcp = "sec_edgar_mcp.server:mcp.run"
+
 [project.optional-dependencies]
 dev = ["ruff>=0.1.14", "mypy>=1.8"]
 


### PR DESCRIPTION
Current implementation only support running the server in docker, which isn't possible from all clients (e.g. when running from another container).

```bash
$ uvx --from git+https://github.com/stefanoamorelli/sec-edgar-mcp.git sec-edgar-mcp

    Updated https://github.com/stefanoamorelli/sec-edgar-mcp.git (51aea44da31330eefa4d0d4d5a23865615c9e97a)

Package `sec-edgar-mcp` does not provide any executables.
```

This PR allows the server to be executed using `uvx sec-edgar-mcp` (see configuration below).

```json
"sec-edgar": {
      "command": "uvx",
      "args": ["--from", "git+https://github.com/stefanoamorelli/sec-edgar-mcp.git", "sec-edgar-mcp"],
      "env": {
        "SEC_EDGAR_USER_AGENT": "John Doe (john.doe@gmail.com)"
      }
}
```