### PR TITLE
fix: update get_recent_filings for issue #45

### DIFF
--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -110,7 +110,7 @@ All SEC Edgar MCP tools follow these core principles:
     - `identifier` (string, optional): Company CIK, ticker, or name
     - `form_type` (string/array, optional): Specific form types (e.g., "10-K", ["10-K", "10-Q"])
     - `days` (number): Number of days to look back (default: 30)
-    - `limit` (number): Maximum number of results (default: 50)
+    - `limit` (number): Maximum number of results (default: 40)
     
     **Returns**: List of filings with metadata and direct SEC links
     

--- a/sec_edgar_mcp/server.py
+++ b/sec_edgar_mcp/server.py
@@ -106,7 +106,7 @@ def get_company_facts(identifier: str):
 
 
 # Filing Tools
-def get_recent_filings(identifier: str = None, form_type: str = None, days: int = 30, limit: int = 50):
+def get_recent_filings(identifier: str = None, form_type: str = None, days: int = 30, limit: int = 40):
     """
     Get recent SEC filings for a company or across all companies.
 

--- a/sec_edgar_mcp/tools/filings.py
+++ b/sec_edgar_mcp/tools/filings.py
@@ -1,6 +1,6 @@
 from typing import Dict, Union, List, Optional, Any
 from datetime import datetime
-from edgar import get_filings
+from edgar import get_current_filings
 from ..core.client import EdgarClient
 from ..core.models import FilingInfo
 from ..utils.exceptions import FilingNotFoundError
@@ -18,7 +18,7 @@ class FilingsTools:
         identifier: Optional[str] = None,
         form_type: Optional[Union[str, List[str]]] = None,
         days: int = 30,
-        limit: int = 50,
+        limit: int = 40,
     ) -> ToolResponse:
         """Get recent filings for a company or across all companies."""
         try:
@@ -27,8 +27,8 @@ class FilingsTools:
                 company = self.client.get_company(identifier)
                 filings = company.get_filings(form=form_type)
             else:
-                # Global filings using edgar-tools get_filings()
-                filings = get_filings(form=form_type, count=limit)
+                # Global filings using edgar-tools get_current_filings()
+                filings = get_current_filings(form=form_type, page_size=limit)
 
             # Limit results
             filings_list = []


### PR DESCRIPTION
Fix as described in https://github.com/stefanoamorelli/sec-edgar-mcp/issues/45

Note: I updated the page size to 40 to match the default value currently in [EdgarTools](https://github.com/dgunning/edgartools/blob/b5daa613d38daf2f42679c7c66000c4c203d4d63/edgar/current_filings.py#L404-L406)