### PR TITLE
chore(deps): upgrade dependencies to resolve security vulnerabilities

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1751,8 +1751,8 @@ name = "uvicorn"
 version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [


### PR DESCRIPTION
Dependabot flagged 20 security alerts in transitive dependencies, including high-severity issues in urllib3, mcp, aiohttp, and starlette.

Running `uv lock --upgrade` updates the lock file to pull in patched versions. The key updates are:
- urllib3 2.4.0 → 2.6.3
- mcp 1.7.1 → 1.26.0
- starlette 0.46.2 → 0.52.1

The aiohttp dependency was removed entirely as it's no longer required by the newer mcp version.

[1]: https://github.com/stefanoamorelli/sec-edgar-mcp/security/dependabot