### PR TITLE
feat(tools): modify truncation logic in get_filing_content

### DIFF
--- a/sec_edgar_mcp/server.py
+++ b/sec_edgar_mcp/server.py
@@ -122,18 +122,20 @@ def get_recent_filings(identifier: str = None, form_type: str = None, days: int 
     return filings_tools.get_recent_filings(identifier, form_type, days, limit)
 
 
-def get_filing_content(identifier: str, accession_number: str):
+def get_filing_content(identifier: str, accession_number: str, offset: int = 0, max_chars: int = 50000):
     """
-    Get the content of a specific SEC filing.
+    Get the content of a specific SEC filing with paging support.
 
     Args:
         identifier: Company ticker symbol or CIK number
         accession_number: The accession number of the filing
+        offset: Character offset into the filing content (default: 0)
+        max_chars: Maximum number of characters to return (default: 50000)
 
     Returns:
-        Dictionary containing filing content and metadata
+        Dictionary containing filing content page and pagination metadata
     """
-    return filings_tools.get_filing_content(identifier, accession_number)
+    return filings_tools.get_filing_content(identifier, accession_number, offset, max_chars)
 
 
 def analyze_8k(identifier: str, accession_number: str):


### PR DESCRIPTION
**Motivation**
Current truncation logic in `get_filing_content` seems insufficient to read long filings. An extreme example:
<img width="1190" height="520" alt="image" src="https://github.com/user-attachments/assets/948cf576-67f1-4707-8efe-4937d5dc209d" />

**What does this PR do**
This PR improves the truncation behavior of `get_filing_content` by adding pagination support via two new parameters: offset and max_chars.

Clients can call `get_filing_content` repeatedly to retrieve long filings in chunks (e.g., offset=0, max_chars=50000 for the first page; then offset=50000, max_chars=50000 for the next page), making it possible to read content beyond the initial 50k-character limit.

The response now also keeps pagination metadata (total_chars, returned_chars, and next_offset) to make iterating straightforward.

**Verification**
Using the above (extreme) example:
<img width="1748" height="1106" alt="feb67abbdf408c13603f1516d6eecc7e" src="https://github.com/user-attachments/assets/ab675c17-7dac-4ce1-adbd-254f0ebd286d" />
