### PR TITLE
fix(filings): degrade gracefully when period_of_report is not ISO-formatted

### DIFF
--- a/sec_edgar_mcp/tools/base.py
+++ b/sec_edgar_mcp/tools/base.py
@@ -23,7 +23,10 @@ class BaseTools:
         if isinstance(date_value, date):
             return datetime.combine(date_value, datetime.min.time())
         if isinstance(date_value, str):
-            return datetime.fromisoformat(date_value.replace("Z", "+00:00"))
+            try:
+                return datetime.fromisoformat(date_value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
         return None
 
     def _format_date(self, date_value) -> str:

--- a/tests/test_base_parse_date.py
+++ b/tests/test_base_parse_date.py
@@ -1,0 +1,55 @@
+"""Tests for BaseTools._parse_date."""
+
+from datetime import date, datetime
+from unittest.mock import patch
+
+from sec_edgar_mcp.tools.base import BaseTools
+
+
+def _make_base():
+    with patch("sec_edgar_mcp.tools.base.EdgarClient"):
+        return BaseTools()
+
+
+def test_parse_date_returns_none_for_non_iso_string():
+    # Regression: upstream edgartools can return a concatenation of filer
+    # names (e.g. from multi-filer Schedule 13D/G homepages) instead of a
+    # period string. _parse_date must degrade gracefully rather than raise.
+    base = _make_base()
+    garbage = "FILER ONE LLCFILER TWO INC.FILER THREE LP"
+    assert base._parse_date(garbage) is None
+
+
+def test_parse_date_returns_none_for_empty_string():
+    base = _make_base()
+    assert base._parse_date("") is None
+
+
+def test_parse_date_parses_iso_string():
+    base = _make_base()
+    result = base._parse_date("2024-05-01")
+    assert result == datetime(2024, 5, 1)
+
+
+def test_parse_date_parses_iso_string_with_z():
+    base = _make_base()
+    result = base._parse_date("2024-05-01T12:00:00Z")
+    assert result is not None
+    assert result.year == 2024 and result.month == 5 and result.day == 1
+
+
+def test_parse_date_passes_through_datetime():
+    base = _make_base()
+    dt = datetime(2024, 1, 1, 12, 0, 0)
+    assert base._parse_date(dt) is dt
+
+
+def test_parse_date_converts_date_to_datetime():
+    base = _make_base()
+    result = base._parse_date(date(2024, 1, 1))
+    assert result == datetime(2024, 1, 1)
+
+
+def test_parse_date_none_returns_none():
+    base = _make_base()
+    assert base._parse_date(None) is None


### PR DESCRIPTION
## Symptom

  `get_recent_filings` raises `ValueError: Invalid isoformat string: '<concatenated filer names>'`
  when sweeping multi-filer Schedule 13D/13G filings.

  Reproducer (requires `SEC_EDGAR_USER_AGENT`):

  ```python
  from sec_edgar_mcp.tools.filings import FilingsTools
  FilingsTools().get_recent_filings(
      identifier="921669",
      form_type="SC 13G",
      days=7000,
      limit=10,
  )
  ```

  Other form types (13F-HR, 10-K, 8-K) work for the same CIK — the crash is specific to multi-filer
   Schedule 13D/G.

## Root cause

  Upstream `edgartools` (`edgar/attachments.py::FilingHomepage.get_filing_dates`) picks the "Period
   of Report" block positionally as `formGrouping[1]`. On multi-filer Schedule 13D/G homepages,
  that block is actually the **Filer(s)** list, and BeautifulSoup's `.text.strip()` flattens each
  filer's name into one concatenated string. That string is returned as `filing.period_of_report`
  and fed into `datetime.fromisoformat()` in `BaseTools._parse_date`, which raises.

  The upstream positional-lookup bug should still be fixed in `edgartools` separately (label-based
  lookup against `<div class="infoHead">` text), but this wrapper should not crash the whole
  `get_recent_filings` call — or silently drop every affected filing via `_create_filing_info`'s
  broad `except Exception: return None`.

## Fix

  Defense-in-depth at the wrapper boundary: `_parse_date` now catches `ValueError` from
  `datetime.fromisoformat` and returns `None`, so the filing is still returned, just without a
  `period_of_report`.

## Tests

  New `tests/test_base_parse_date.py` covers the non-ISO regression plus happy paths (ISO date, ISO
   datetime with `Z`, datetime/date passthrough, `None`).

## Test plan

  - [x] `pytest tests/` — 7 passed
  - [x] Ran reproducer against CIK 921669 `SC 13G` — 10 filings returned, each with
  `period_of_report=None`, no crash