### PR TITLE
fix: populate empty tool descriptions caused by f-string docstrings (#97)

### DIFF
--- a/sec_edgar_mcp/server.py
+++ b/sec_edgar_mcp/server.py
@@ -79,7 +79,7 @@ def search_companies(query: str, limit: int = 10):
 
 
 def get_company_facts(identifier: str):
-    f"""
+    """
     Retrieve all available XBRL facts for a company from SEC filings.
 
     Args:
@@ -171,7 +171,7 @@ def get_filing_sections(identifier: str, accession_number: str, form_type: str):
 
 
 def get_financials(identifier: str, statement_type: str = "all"):
-    f"""
+    """
     Extract financial statements from the latest SEC filing.
 
     <when-to-use>
@@ -197,7 +197,7 @@ def get_financials(identifier: str, statement_type: str = "all"):
 
 
 def get_segment_data(identifier: str, segment_type: str = "geographic"):
-    f"""
+    """
     Get revenue breakdown by business or geographic segments.
 
     Args:
@@ -212,7 +212,7 @@ def get_segment_data(identifier: str, segment_type: str = "geographic"):
 
 
 def get_key_metrics(identifier: str, metrics: list = None):
-    f"""
+    """
     Retrieve specific financial metrics from SEC filings.
 
     Args:
@@ -227,7 +227,7 @@ def get_key_metrics(identifier: str, metrics: list = None):
 
 
 def compare_periods(identifier: str, metric: str, start_year: int, end_year: int):
-    f"""
+    """
     Compare a financial metric across multiple fiscal years.
 
     Args:
@@ -265,7 +265,7 @@ def get_xbrl_concepts(
     concepts: list = None,
     form_type: str = "10-K",
 ):
-    f"""
+    """
     Extract specific XBRL concepts from a filing.
 
     <note>For general financial data, prefer get_financials() instead.
@@ -313,7 +313,7 @@ def discover_xbrl_concepts(
 
 
 def get_insider_transactions(identifier: str, form_types: list = None, days: int = 90, limit: int = 50):
-    f"""
+    """
     Get insider trading transactions from Forms 3, 4, and 5.
 
     <when-to-use>
@@ -354,7 +354,7 @@ def get_insider_summary(identifier: str, days: int = 180):
 
 
 def get_form4_details(identifier: str, accession_number: str):
-    f"""
+    """
     Get detailed information from a specific Form 4 filing.
 
     Args:
@@ -369,7 +369,7 @@ def get_form4_details(identifier: str, accession_number: str):
 
 
 def analyze_form4_transactions(identifier: str, days: int = 90, limit: int = 50):
-    f"""
+    """
     Extract detailed transaction data from Form 4 filings.
 
     <tip>Use this for comprehensive insider transaction analysis including
@@ -521,6 +521,11 @@ def register_tools(mcp: FastMCP):
         get_recommended_tools,
     ]
     for tool in tools:
+        # Python does not store an f-string expression in docstring position as
+        # __doc__, so tools that reuse the shared instructions declare a plain
+        # docstring with a {_FINANCIAL_INSTRUCTIONS} placeholder, expanded here.
+        if tool.__doc__ and "{_FINANCIAL_INSTRUCTIONS}" in tool.__doc__:
+            tool.__doc__ = tool.__doc__.replace("{_FINANCIAL_INSTRUCTIONS}", _FINANCIAL_INSTRUCTIONS)
         mcp.add_tool(tool)
 
 

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -1,0 +1,38 @@
+"""Tests that every registered MCP tool exposes a non-empty description.
+
+Regression for #97: several tool functions declared their docstring as an
+f-string. Python does not store an f-string expression in docstring position as
+``__doc__``, so those tools registered with an empty MCP description. The server
+now uses plain docstrings with a ``{_FINANCIAL_INSTRUCTIONS}`` placeholder that
+``register_tools`` expands, so descriptions must be populated for every tool.
+"""
+
+from unittest.mock import patch
+
+from mcp.server.fastmcp import FastMCP
+
+
+def _registered_tools():
+    with patch("sec_edgar_mcp.tools.base.EdgarClient"):
+        from sec_edgar_mcp import server
+
+        mcp = FastMCP("test")
+        server.register_tools(mcp)
+        return mcp._tool_manager.list_tools()
+
+
+def test_every_tool_has_a_nonempty_description():
+    tools = _registered_tools()
+    assert tools, "no tools were registered"
+    empty = [t.name for t in tools if not (t.description or "").strip()]
+    assert not empty, f"tools registered with an empty description: {empty}"
+
+
+def test_shared_financial_instructions_are_injected():
+    tools = {t.name: t for t in _registered_tools()}
+    # get_financials reuses the shared _FINANCIAL_INSTRUCTIONS block via the
+    # placeholder; after expansion its description must contain that block and
+    # must not still contain the raw placeholder.
+    desc = tools["get_financials"].description or ""
+    assert "<instructions>" in desc
+    assert "{_FINANCIAL_INSTRUCTIONS}" not in desc


### PR DESCRIPTION
## Problem

Nine tools register with an **empty `description`** (reproducible via a `tools/list` call, as reported in #97):

`get_company_facts`, `get_financials`, `get_segment_data`, `get_key_metrics`, `compare_periods`, `get_xbrl_concepts`, `get_insider_transactions`, `get_form4_details`, `analyze_form4_transactions`.

Root cause: each of these declared its docstring as an **f-string** (to interpolate the shared `_FINANCIAL_INSTRUCTIONS` block). Python does not treat an f-string expression in docstring position as `__doc__` (it stays `None`), so FastMCP has nothing to use for the tool description.

## Fix

- Change those 9 docstrings from `f"""..."""` to plain `"""..."""` with a literal `{_FINANCIAL_INSTRUCTIONS}` placeholder.
- Expand the placeholder in `register_tools` before `mcp.add_tool(...)`, preserving the shared-instructions reuse. As a bonus, `__doc__` / `help()` now work for these functions too.

## Verification

Registering the tools and inspecting descriptions:

- **Before:** 9 tools with empty descriptions.
- **After:** all 21 tools have non-empty descriptions and the shared instructions are injected (e.g. `get_financials` goes from 0 to ~1.3k chars, containing `<instructions>`).

Added `tests/test_tool_descriptions.py` (asserts every registered tool has a non-empty description, and that the shared instructions are expanded). Full suite: **9 passed**; `ruff` clean.

Closes #97.