### PR TITLE
fix: use EntityFacts.get_fact() API instead of non-existent .data dict

### DIFF
--- a/sec_edgar_mcp/tools/company.py
+++ b/sec_edgar_mcp/tools/company.py
@@ -70,17 +70,17 @@ class CompanyTools(BaseTools):
             return {"success": False, "error": f"Failed to get company facts: {e}"}
 
     def _extract_metrics(self, facts) -> Dict[str, Any]:
-        """Extract key financial metrics from company facts."""
+        """Extract key financial metrics from company facts using get_fact() API.
+
+        The edgar-tools ``EntityFacts`` object does not expose a ``.data`` dict;
+        each concept is retrieved via ``get_fact(name)`` which returns a
+        ``FinancialFact`` or ``None``.  Most US-GAAP concepts require the
+        ``us-gaap:`` namespace prefix to be found reliably.
+        """
+        import warnings
+
         metrics: Dict[str, Any] = {}
 
-        if not hasattr(facts, "data"):
-            return metrics
-
-        facts_data = facts.data
-        if "us-gaap" not in facts_data:
-            return metrics
-
-        gaap_facts = facts_data["us-gaap"]
         metric_names = [
             "Assets",
             "Liabilities",
@@ -88,33 +88,30 @@ class CompanyTools(BaseTools):
             "Revenues",
             "NetIncomeLoss",
             "EarningsPerShareBasic",
-            "CashAndCashEquivalents",
+            "CashAndCashEquivalentsAtCarryingValue",
             "CommonStockSharesOutstanding",
         ]
 
         for metric in metric_names:
-            if metric not in gaap_facts:
-                continue
-
-            metric_data = gaap_facts[metric]
-            if "units" not in metric_data:
-                continue
-
-            for unit_type, unit_data in metric_data["units"].items():
-                if not unit_data:
+            fact = None
+            for prefix in ("us-gaap:", "", "dei:"):
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        fact = facts.get_fact(f"{prefix}{metric}")
+                    if fact is not None:
+                        break
+                except Exception:
                     continue
 
-                sorted_data = sorted(unit_data, key=lambda x: x.get("end", ""), reverse=True)
-                if sorted_data:
-                    latest = sorted_data[0]
-                    metrics[metric] = {
-                        "value": float(latest.get("val", 0)),
-                        "unit": unit_type,
-                        "period": latest.get("end", ""),
-                        "form": latest.get("form", ""),
-                        "fiscal_year": latest.get("fy", ""),
-                        "fiscal_period": latest.get("fp", ""),
-                    }
-                    break
+            if fact is not None:
+                metrics[metric] = {
+                    "value": float(fact.numeric_value),
+                    "unit": getattr(fact, "unit", "USD"),
+                    "period": str(getattr(fact, "period_end", "")),
+                    "form": getattr(fact, "form_type", ""),
+                    "fiscal_year": getattr(fact, "fiscal_year", ""),
+                    "fiscal_period": getattr(fact, "fiscal_period", ""),
+                }
 
         return metrics

--- a/sec_edgar_mcp/tools/financial.py
+++ b/sec_edgar_mcp/tools/financial.py
@@ -182,7 +182,7 @@ class FinancialTools(BaseTools):
                     "StockholdersEquity",
                     "EarningsPerShareBasic",
                     "CommonStockSharesOutstanding",
-                    "CashAndCashEquivalents",
+                    "CashAndCashEquivalentsAtCarryingValue",
                 ]
 
             result_metrics = self._extract_metrics_from_facts(facts, metrics)
@@ -199,15 +199,42 @@ class FinancialTools(BaseTools):
 
     def compare_periods(self, identifier: str, metric: str, start_year: int, end_year: int) -> ToolResponse:
         """Compare a financial metric across periods."""
+        import warnings
+
         try:
             company = self.client.get_company(identifier)
             facts = company.get_facts()
 
-            fact_data = facts.get_fact(metric)
-            if fact_data is None or fact_data.empty:
+            # get_fact() requires namespace prefix for most concepts
+            fact = None
+            for prefix in ("us-gaap:", "", "dei:"):
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        fact = facts.get_fact(f"{prefix}{metric}")
+                    if fact is not None:
+                        break
+                except Exception:
+                    continue
+
+            if fact is None:
                 return {"success": False, "error": f"No data found for metric: {metric}"}
 
-            period_data = self._filter_by_year_range(fact_data, start_year, end_year)
+            # FinancialFact exposes a single (latest) value, not a DataFrame.
+            # Build a single-period data point from it.
+            year = getattr(fact, "fiscal_year", 0) or 0
+            period_data = []
+            if start_year <= year <= end_year:
+                period_data.append(
+                    {
+                        "year": int(year),
+                        "period": getattr(fact, "fiscal_period", ""),
+                        "value": float(fact.numeric_value),
+                        "unit": getattr(fact, "unit", "USD"),
+                        "form": getattr(fact, "form_type", ""),
+                    }
+                )
+
             analysis = self._calculate_growth(period_data)
 
             return {
@@ -423,42 +450,40 @@ class FinancialTools(BaseTools):
         return filings.latest() if filings else None
 
     def _extract_metrics_from_facts(self, facts, metrics: List[str]) -> Dict[str, Any]:
-        """Extract metrics from company facts."""
+        """Extract metrics from company facts using the EntityFacts.get_fact() API.
+
+        The edgar-tools ``EntityFacts`` object does not expose a ``.data`` dict;
+        instead, each concept is retrieved via ``get_fact(name)`` which returns a
+        ``FinancialFact`` (or ``None`` when the concept is not reported by the
+        company).  Most US-GAAP concepts require the ``us-gaap:`` namespace
+        prefix to be found reliably.
+        """
+        import warnings
+
         result_metrics: Dict[str, Any] = {}
 
-        if not hasattr(facts, "data"):
-            return result_metrics
-
-        facts_data = facts.data
-        if "us-gaap" not in facts_data:
-            return result_metrics
-
-        gaap_facts = facts_data["us-gaap"]
-
         for metric in metrics:
-            if metric not in gaap_facts:
-                continue
-
-            metric_data = gaap_facts[metric]
-            if "units" not in metric_data:
-                continue
-
-            for unit_type, unit_data in metric_data["units"].items():
-                if not unit_data:
+            fact = None
+            # Try us-gaap: prefix first, then bare name, then dei: for DEI concepts
+            for prefix in ("us-gaap:", "", "dei:"):
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        fact = facts.get_fact(f"{prefix}{metric}")
+                    if fact is not None:
+                        break
+                except Exception:
                     continue
 
-                sorted_data = sorted(unit_data, key=lambda x: x.get("end", ""), reverse=True)
-                if sorted_data:
-                    latest = sorted_data[0]
-                    result_metrics[metric] = {
-                        "value": float(latest.get("val", 0)),
-                        "unit": unit_type,
-                        "period": latest.get("end", ""),
-                        "form": latest.get("form", ""),
-                        "fiscal_year": latest.get("fy", ""),
-                        "fiscal_period": latest.get("fp", ""),
-                    }
-                    break
+            if fact is not None:
+                result_metrics[metric] = {
+                    "value": float(fact.numeric_value),
+                    "unit": getattr(fact, "unit", "USD"),
+                    "period": str(getattr(fact, "period_end", "")),
+                    "form": getattr(fact, "form_type", ""),
+                    "fiscal_year": getattr(fact, "fiscal_year", ""),
+                    "fiscal_period": getattr(fact, "fiscal_period", ""),
+                }
 
         return result_metrics
 
@@ -519,7 +544,9 @@ class FinancialTools(BaseTools):
         }
 
     def _discover_facts(self, facts, search_term: Optional[str]) -> List[Dict[str, Any]]:
-        """Discover available facts from company facts."""
+        """Discover available facts from company facts using get_fact() API."""
+        import warnings
+
         available_facts: List[Dict[str, Any]] = []
         common_facts = [
             "Assets",
@@ -534,30 +561,41 @@ class FinancialTools(BaseTools):
             "EarningsPerShareBasic",
             "EarningsPerShareDiluted",
             "CommonStockSharesOutstanding",
-            "CashAndCashEquivalents",
-            "AccountsReceivableNet",
+            "CashAndCashEquivalentsAtCarryingValue",
+            "AccountsReceivableNetCurrent",
             "InventoryNet",
             "PropertyPlantAndEquipmentNet",
             "Goodwill",
-            "IntangibleAssetsNet",
-            "LongTermDebt",
+            "IntangibleAssetsNetExcludingGoodwill",
+            "LongTermDebtNoncurrent",
             "ResearchAndDevelopmentExpense",
             "SellingGeneralAndAdministrativeExpense",
         ]
 
         for fact_name in common_facts:
-            try:
-                fact_data = facts.get_fact(fact_name)
-                if fact_data is not None and not fact_data.empty:
-                    if not search_term or search_term.lower() in fact_name.lower():
-                        available_facts.append(
-                            {
-                                "name": fact_name,
-                                "count": len(fact_data),
-                                "latest_period": fact_data.iloc[-1].get("end", "") if not fact_data.empty else None,
-                            }
-                        )
-            except Exception:
-                continue
+            fact = None
+            for prefix in ("us-gaap:", "", "dei:"):
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        fact = facts.get_fact(f"{prefix}{fact_name}")
+                    if fact is not None:
+                        break
+                except Exception:
+                    continue
+
+            if fact is not None:
+                if not search_term or search_term.lower() in fact_name.lower():
+                    available_facts.append(
+                        {
+                            "name": fact_name,
+                            "value": float(fact.numeric_value),
+                            "unit": getattr(fact, "unit", "USD"),
+                            "period": str(getattr(fact, "period_end", "")),
+                            "form": getattr(fact, "form_type", ""),
+                            "fiscal_year": getattr(fact, "fiscal_year", ""),
+                            "fiscal_period": getattr(fact, "fiscal_period", ""),
+                        }
+                    )
 
         return available_facts


### PR DESCRIPTION
## Summary

Fixes #111 — `get_key_metrics`, `get_company_facts`, `discover_company_metrics`, and `compare_periods` all return empty results or raise exceptions for every company.

## Root Cause

The edgar-tools `EntityFacts` object does **not** expose a `.data` dict attribute. The code checked `hasattr(facts, "data")` which always returned `False`, so the entire metrics extraction block was silently skipped.

Additionally, `facts.get_fact(name)` requires the `us-gaap:` namespace prefix for most concepts (e.g. `NetIncomeLoss`, `StockholdersEquity`, `EarningsPerShareBasic`). Without the prefix, it returns `None` even when the concept exists in the company's XBRL data. Only a few concepts (`Revenues`, `Assets`, `Liabilities`) happen to be found without the prefix.

A third issue: `compare_periods` and `_discover_facts` called `.empty` and `.iloc[-1]` on the returned `FinancialFact` object — these are pandas DataFrame APIs that don't exist on `FinancialFact`, causing `AttributeError` on every call.

## Fix

- **`_extract_metrics_from_facts`** (financial.py): Replaced `facts.data["us-gaap"][metric]` dict access with `facts.get_fact(f"us-gaap:{metric}")` API, trying `us-gaap:`, bare, and `dei:` prefixes.
- **`_extract_metrics`** (company.py): Same fix — replaced broken `.data` dict access with `get_fact()` API.
- **`_discover_facts`** (financial.py): Replaced `.empty`/`.iloc` DataFrame checks with `get_fact()` API; also corrected several XBRL concept names that didn't match the actual us-gaap taxonomy.
- **`compare_periods`** (financial.py): Replaced `.empty` check with `get_fact()` API; builds period data from the `FinancialFact` object directly.
- **Concept name fixes**: `CashAndCashEquivalents` → `CashAndCashEquivalentsAtCarryingValue`, `AccountsReceivableNet` → `AccountsReceivableNetCurrent`, `IntangibleAssetsNet` → `IntangibleAssetsNetExcludingGoodwill`, `LongTermDebt` → `LongTermDebtNoncurrent`.

## Verification

Tested with NVDA (CIK 0001045810) via `uvx sec-edgar-mcp`:

**Before** — `get_key_metrics`:
```json
{"metrics": {}, "found_metrics": []}
```

**After** — `get_key_metrics`:
```json
{"metrics": {
  "Revenues": {"value": 81615000000, "unit": "USD", "fiscal_year": 2027, "fiscal_period": "Q1"},
  "NetIncomeLoss": {"value": 58321000000, "unit": "USD", "fiscal_year": 2027, "fiscal_period": "Q1"},
  "Assets": {"value": 259474000000, "unit": "USD", "fiscal_year": 2027, "fiscal_period": "Q1"},
  ...
}, "found_metrics": ["Revenues", "NetIncomeLoss", "Assets", "Liabilities", "StockholdersEquity", "EarningsPerShareBasic", "CommonStockSharesOutstanding", "CashAndCashEquivalentsAtCarryingValue"]}
```

`discover_company_metrics` now returns 21 metrics (was 0). `get_company_facts` now returns 8 metrics (was 0). `compare_periods` no longer raises `AttributeError`.

Tested with: `SEC_EDGAR_USER_AGENT='test test@test.com'` + Python 3.11 + edgar-tools.