### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://mseep.ai/app/0132880c-5e83-410b-a1d5-d3df08ed7b5c"><img alt="Verified on MseeP" src="https://mseep.ai/badge.svg" /></a>
   <a href="https://doi.org/10.5281/zenodo.17123166"><img alt="DOI" src="https://zenodo.org/badge/DOI/10.5281/zenodo.17123166.svg" /></a>
   <a href="https://github.com/stefanoamorelli/sec-edgar-mcp/actions/workflows/evals.yml"><img alt="Evals" src="https://github.com/stefanoamorelli/sec-edgar-mcp/actions/workflows/evals.yml/badge.svg" /></a>
+  <a href="https://mcpvitals.com/status/5a2a10732c"><img alt="MCP status" src="https://mcpvitals.com/badge/5a2a10732c.svg" /></a>
 </p>
 
 MCP server for accessing SEC EDGAR filings. Connects AI assistants to company filings, financial statements, and insider trading data with exact numeric precision.


### PR DESCRIPTION
Hi Stefano 👋

Nice work on sec-edgar-mcp. I run [MCP Vitals](https://mcpvitals.com) and set up a free public monitor for your hosted endpoint (`sec-edgar-mcp.amorelli.tech/mcp`) — real handshake checks every few minutes, currently healthy with 3 tools.

This PR adds a live status badge to your existing badge row so users know the EDGAR server is up before they wire it in — and it flags downtime / tool-schema drift:

[![MCP status](https://mcpvitals.com/badge/5a2a10732c.svg)](https://mcpvitals.com/status/5a2a10732c)

Free, links to a public uptime/latency page, nothing to sign up for. Feel free to close if you'd rather not — and if you'd like to own the monitor, it's a 2-minute setup. 🙏
