### PR TITLE
fix(8-K): handle date_of_report as datetime.date in analyze_8k (fixes #160)

### DIFF
--- a/sec_edgar_mcp/tools/filings.py
+++ b/sec_edgar_mcp/tools/filings.py
@@ -146,11 +146,17 @@ class FilingsTools(BaseTools):
             "events": {},
         }
 
-        if hasattr(eightk, "date_of_report"):
-            try:
-                analysis["date_of_report"] = datetime.strptime(eightk.date_of_report, "%B %d, %Y").isoformat()
-            except (ValueError, TypeError):
-                pass
+        date_of_report = getattr(eightk, "date_of_report", None)
+        if date_of_report is not None:
+            if hasattr(date_of_report, "isoformat"):
+                # Current edgartools returns a datetime.date/datetime object.
+                analysis["date_of_report"] = date_of_report.isoformat()
+            else:
+                # Legacy string form ("%B %d, %Y").
+                try:
+                    analysis["date_of_report"] = datetime.strptime(date_of_report, "%B %d, %Y").isoformat()
+                except (ValueError, TypeError):
+                    pass
 
         item_descriptions = {
             "1.01": "Entry into Material Agreement",


### PR DESCRIPTION
## Problem

`edgartools` (tested 5.46.0) returns an 8-K's `date_of_report` as a `datetime.date`, but `_analyze_8k_content` passes it to `datetime.strptime(..., "%B %d, %Y")`, which requires a `str`:

- **v1.0.8 (released): every `analyze_8k` call hard-crashes** with `strptime() argument 1 must be str, not datetime.date` (the `strptime` sits in a dict literal with no `try`).
- **`main`: no crash, but `date_of_report` is always `null`** — the call is wrapped in `try/except (ValueError, TypeError): pass`, so `hasattr` passes, `strptime` fails on the date object, and the field is silently dropped.

Fixes #160.

## Change

Detect a date/datetime object and call `.isoformat()` directly; fall back to `strptime` only for the legacy `"%B %d, %Y"` string form. This re-applies the approach from #140 (self-closed by its author, unreviewed) against current `main`.

## Verification

Ran the patched code against two 8-Ks that crash on the released MCP:

```
BW   0001104659-26-082840 -> success=True, date_of_report='2026-07-13'
INTT 0001036262-26-000042 -> success=True, date_of_report='2026-08-10'
```

Unit checks on `_analyze_8k_content`:

```
datetime.date(2026, 7, 13) -> '2026-07-13'      (isoformat path)
'July 13, 2026'            -> '2026-07-13T00:00:00' (legacy strptime fallback)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
