### PR TITLE
docs: fix the DOI badge and drop the conda one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 <p align="center">
   <a href="https://pypi.org/project/sec-edgar-mcp/"><img alt="PyPI" src="https://img.shields.io/pypi/v/sec-edgar-mcp.svg" /></a>
-  <a href="https://anaconda.org/stefanoamorelli/sec-edgar-mcp"><img alt="Conda Version" src="https://img.shields.io/conda/vn/stefanoamorelli/sec-edgar-mcp.svg" /></a>
   <img alt="Python: 3.11+" src="https://img.shields.io/badge/python-3.11+-brightgreen.svg" />
   <img alt="License: AGPL-3.0" src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" />
-  <a href="https://doi.org/10.5281/zenodo.17123166"><img alt="DOI" src="https://zenodo.org/badge/DOI/10.5281/zenodo.17123166.svg" /></a>
+  <a href="https://doi.org/10.5281/zenodo.17123165"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17123165-blue.svg" /></a>
   <a href="https://github.com/stefanoamorelli/sec-edgar-mcp/actions/workflows/evals.yml"><img alt="Evals" src="https://github.com/stefanoamorelli/sec-edgar-mcp/actions/workflows/evals.yml/badge.svg" /></a>
 </p>
 
@@ -46,7 +45,7 @@ https://github.com/user-attachments/assets/d310eb42-b3ca-467d-92f7-7d132e6274fe
 
 The `-i` flag is required for MCP's JSON-RPC communication.
 
-For other installation methods (pip, conda, uv), see the [documentation](https://sec-edgar-mcp.amorelli.tech/setup/quickstart).
+For other installation methods (pip, uv), see the [documentation](https://sec-edgar-mcp.amorelli.tech/setup/quickstart).
 
 ## Tools
 


### PR DESCRIPTION
The DOI badge rendered blank on GitHub: the image proxy returns 502 for Zenodo's badge endpoint, even though the endpoint itself serves fine when fetched directly. It now uses a shields-hosted image, like every other badge here.

It also pointed at the version-specific DOI for v1.0.6. It now uses the concept DOI, which always resolves to the newest deposit — currently v1.1.0.

The conda badge showed `conda: not found` because no channel exists: `api.anaconda.org/user/stefanoamorelli` returns "could not be found". Dropped it, along with conda from the list of install methods.