### PR TITLE
feat: add form selection to get_financials

### DIFF
--- a/sec_edgar_mcp/server.py
+++ b/sec_edgar_mcp/server.py
@@ -170,9 +170,9 @@ def get_filing_sections(identifier: str, accession_number: str, form_type: str):
 # =============================================================================
 
 
-def get_financials(identifier: str, statement_type: str = "all"):
+def get_financials(identifier: str, statement_type: str = "all", form_type: str = None):
     f"""
-    Extract financial statements from the latest SEC filing.
+    Extract financial statements from the latest matching SEC filing.
 
     <when-to-use>
       Use this tool when users ask about income statements, revenue, net income,
@@ -183,6 +183,8 @@ def get_financials(identifier: str, statement_type: str = "all"):
     Args:
         identifier: Company ticker symbol or CIK number
         statement_type: "income", "balance", "cash", or "all" (default: "all")
+        form_type: "10-K" or "10-Q". When omitted, the latest of either form
+            is used.
 
     Returns:
         Financial statement data with exact values from XBRL.
@@ -193,7 +195,7 @@ def get_financials(identifier: str, statement_type: str = "all"):
       <period>Note the fiscal period end date.</period>
     </presentation>
     """
-    return financial_tools.get_financials(identifier, statement_type)
+    return financial_tools.get_financials(identifier, statement_type, form_type)
 
 
 def get_segment_data(identifier: str, segment_type: str = "geographic"):

--- a/sec_edgar_mcp/tools/financial.py
+++ b/sec_edgar_mcp/tools/financial.py
@@ -18,13 +18,26 @@ class FinancialTools(BaseTools):
         super().__init__()
         self.xbrl_extractor = XBRLExtractor()
 
-    def get_financials(self, identifier: str, statement_type: str = "all") -> ToolResponse:
-        """Get financial statements from the latest SEC filing."""
+    def get_financials(
+        self,
+        identifier: str,
+        statement_type: str = "all",
+        form_type: Optional[str] = None,
+    ) -> ToolResponse:
+        """Get financial statements from the latest matching SEC filing."""
         try:
+            if form_type not in (None, "10-K", "10-Q"):
+                return {"success": False, "error": 'form_type must be "10-K" or "10-Q"'}
+
             company = self.client.get_company(identifier)
-            latest_filing, form_type = self._get_latest_financial_filing(company)
+            if form_type:
+                latest_filing = company.get_filings(form=form_type).latest()
+            else:
+                latest_filing, form_type = self._get_latest_financial_filing(company)
 
             if not latest_filing:
+                if form_type:
+                    return {"success": False, "error": f"No {form_type} filings found"}
                 return {"success": False, "error": "No 10-K or 10-Q filings found"}
 
             financials = self._extract_financials(latest_filing, company, form_type)

--- a/tests/test_financial_form_type.py
+++ b/tests/test_financial_form_type.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock, patch
+
+from sec_edgar_mcp.tools.financial import FinancialTools
+
+
+def _make_tools():
+    with patch("sec_edgar_mcp.tools.base.EdgarClient"):
+        return FinancialTools()
+
+
+def test_get_financials_uses_requested_form():
+    tools = _make_tools()
+    filing = Mock()
+    company = Mock(cik="0000000000", name="Example Corp")
+    company.get_filings.return_value.latest.return_value = filing
+    tools.client = Mock()
+    tools.client.get_company.return_value = company
+    tools._extract_financials = Mock(return_value=object())
+    tools._get_xbrl = Mock(return_value=None)
+    tools._extract_statements = Mock(return_value={})
+    tools._create_filing_reference = Mock(return_value={})
+
+    result = tools.get_financials("EXAMPLE", form_type="10-K")
+
+    assert result["success"] is True
+    assert result["form_type"] == "10-K"
+    company.get_filings.assert_called_once_with(form="10-K")
+
+
+def test_get_financials_reports_missing_requested_form():
+    tools = _make_tools()
+    company = Mock()
+    company.get_filings.return_value.latest.return_value = None
+    tools.client = Mock()
+    tools.client.get_company.return_value = company
+
+    result = tools.get_financials("EXAMPLE", form_type="10-K")
+
+    assert result == {"success": False, "error": "No 10-K filings found"}
+
+
+def test_get_financials_rejects_other_forms():
+    tools = _make_tools()
+
+    result = tools.get_financials("EXAMPLE", form_type="8-K")
+
+    assert result == {"success": False, "error": 'form_type must be "10-K" or "10-Q"'}


### PR DESCRIPTION
`get_financials` currently uses whichever of the latest 10-K and 10-Q was filed most recently. An annual request can therefore return quarterly data.

Add an optional `form_type` argument for choosing `10-K` or `10-Q`. Existing calls are unchanged.